### PR TITLE
Update package.json to use latest LTS for Node.js and npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "typescript": "^3.0.3"
   },
   "engines": {
-    "node": "^8.11",
-    "npm": "^5.6"
+    "node": "^10.15",
+    "npm": "^6.4"
   },
   "files": [
     "lib"


### PR DESCRIPTION
To use latest node.js LTS , we need not only #108 for local development but also this PR for Heroku.