### PR TITLE
fix: skip build by semantic-release

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ on:
 steps:
   ...
   - name: Build staging document
-    uses: KengoTODA/rtd-bot@actions-v0.8.0
+    uses: KengoTODA/rtd-bot@actions-v0.8.1
     env:
       RTD_USERNAME: your_rtd_username
       RTD_PASSWORD: ${{ secrets.RTD_PASSWORD }}

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
       "@semantic-release/changelog",
       "@semantic-release/npm",
       "@semantic-release/git"
-    ]
+    ],
+    "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
To release for github actions, a build should be triggered when tag `vMAJOR.MINOR.PATCH` has been released. So we need to remove `[skip ci]` in the commit message.