### PR TITLE
Add types modules to build

### DIFF
--- a/.github/workflows/release-actions.yml
+++ b/.github/workflows/release-actions.yml
@@ -30,7 +30,7 @@ jobs:
           git config --local user.name "GitHub Action"
           git checkout -b release-actions-$VERSION
 
-          npm install --production
+          npm ci
           git add --force node_modules
 
           npm pack

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ on:
 steps:
   ...
   - name: Build staging document
-    uses: KengoTODA/rtd-bot@actions-v0.8.3
+    uses: KengoTODA/rtd-bot@actions-v0.8.4
     env:
       RTD_USERNAME: your_rtd_username
       RTD_PASSWORD: ${{ secrets.RTD_PASSWORD }}


### PR DESCRIPTION
The build in master branch is failing, because we have no `@types/*` module to build.
https://github.com/KengoTODA/rtd-bot/runs/444437484