### PR TITLE
Do not run tsc in start build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "start": "tsc && probot run ./lib/index.js",
+    "start": "probot run ./lib/index.js",
     "travis-deploy-once": "travis-deploy-once --pro",
     "semantic-release": "semantic-release",
     "test": "cross-env TS_NODE_FILES=true nyc mocha",
+    "postinstall": "npm run-script prepack",
     "prepack": "tsc"
   },
   "keywords": [
@@ -54,8 +55,7 @@
     "type": "git",
     "url": "https://github.com/KengoTODA/rtd-bot.git"
   },
-  "release": {
-  },
+  "release": {},
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
currently we need `NPM_CONFIG_PRODUCTION=false` config to run service on
Heroku, or `npm start` fails due to lack of `tsc` command.
https://devcenter.heroku.com/articles/nodejs-support#package-installation

by this change, we compile .ts files at deploy phase, so
when run `npm start` we do not need `tsc` and other devDependencies.