### PR TITLE
Follow recent update on the Probot side

### DIFF
--- a/action/index.d.ts
+++ b/action/index.d.ts
@@ -1,3 +1,3 @@
-import { Application } from "probot";
-declare const _default: (app: Application) => void;
+import { ApplicationFunctionOptions, Probot } from "probot";
+declare const _default: (app: Probot, { getRouter }: ApplicationFunctionOptions) => void;
 export = _default;

--- a/action/index.js
+++ b/action/index.js
@@ -21753,7 +21753,11 @@ dotenv.config();
 var express_1 = __importDefault(__webpack_require__(754));
 var build_body_1 = __importDefault(__webpack_require__(735));
 var rtd_1 = __importDefault(__webpack_require__(272));
-module.exports = function (app) {
+module.exports = function (app, _a) {
+    var getRouter = _a.getRouter;
+    if (!getRouter) {
+        throw new Error("getRouter is required to use the rtd-bot app");
+    }
     app.on("pull_request", function (context) { return __awaiter(void 0, void 0, void 0, function () {
         var log, token, rtd, config, project, head, files, branch, translates, disabled, enabled, body;
         return __generator(this, function (_a) {
@@ -21771,14 +21775,14 @@ module.exports = function (app) {
                 case 1:
                     config = _a.sent();
                     if (config === null) {
-                        context.github.issues.createComment(context.issue({
+                        context.octokit.issues.createComment(context.issue({
                             body: "The rtd-bot is activated, but no .github/config.yml found in this repository.\n"
                                 + "Make sure that you have it in your default branch.",
                         }));
                         return [2 /*return*/];
                     }
                     if (config.rtd.project === "") {
-                        context.github.issues.createComment(context.issue({
+                        context.octokit.issues.createComment(context.issue({
                             body: "The rtd-bot is activated, but .github/config.yml does not have necessary configuration.\n"
                                 + "Make sure that you have it in your default branch.",
                         }));
@@ -21793,7 +21797,7 @@ module.exports = function (app) {
                         log.debug("PR made from another Git repo is not supported.");
                         return [2 /*return*/];
                     }
-                    return [4 /*yield*/, context.github.paginate(context.github.pulls.listFiles, context.pullRequest({}))];
+                    return [4 /*yield*/, context.octokit.paginate(context.octokit.pulls.listFiles, context.pullRequest({}))];
                 case 2:
                     files = _a.sent();
                     if (undefined === files.find(function (file) { return file.filename.startsWith('docs/'); })) {
@@ -21815,7 +21819,7 @@ module.exports = function (app) {
                         })).then(function (allResult) {
                             return allResult.reduce(function (l, r) { return l || r; });
                         }).catch(function (e) {
-                            context.github.issues.createComment(context.issue({
+                            context.octokit.issues.createComment(context.issue({
                                 body: e.message,
                             }));
                             throw e;
@@ -21838,7 +21842,7 @@ module.exports = function (app) {
                     })).then(function (allResult) {
                         return allResult.reduce(function (l, r) { return l || r; });
                     }).catch(function (e) {
-                        context.github.issues.createComment(context.issue({
+                        context.octokit.issues.createComment(context.issue({
                             body: e.message,
                         }));
                         throw e;
@@ -21848,7 +21852,7 @@ module.exports = function (app) {
                     if (enabled) {
                         log.debug("Reporting document URL to GitHub PR page of " + branch + " branch in " + project + ".");
                         body = build_body_1.default(context.payload.pull_request.body, project, branch, translates.map(function (t) { return t.language; }));
-                        context.github.issues.update(context.issue({
+                        context.octokit.issues.update(context.issue({
                             body: body,
                         }));
                     }
@@ -21860,11 +21864,10 @@ module.exports = function (app) {
             }
         });
     }); });
-    var router = app.route("/welcome");
-    router.get("/", function (req, res) {
+    getRouter("/welcome").get("/", function (req, res) {
         res.sendFile(__dirname + "/welcome.html");
     });
-    app.route("/static").use(express_1.default.static("asset"));
+    getRouter("/static").use(express_1.default.static("asset"));
 };
 
 

--- a/action/index.js
+++ b/action/index.js
@@ -21805,7 +21805,7 @@ module.exports = function (app, _a) {
                         return [2 /*return*/];
                     }
                     branch = head.ref;
-                    log.debug("Confirmed configuration of %s branch in %s: %s", branch, project, config);
+                    log.debug("Confirmed configuration of %s branch in %s: %s", branch, project, JSON.stringify(config));
                     return [4 /*yield*/, rtd.getTranslates(project)];
                 case 3:
                     translates = _a.sent();

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@actions/core": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.5.tgz",
-      "integrity": "sha512-mwpoNjHSWWh0IiALdDEQi3tru124JKn0yVNziIBzTME8QRv7thwoghVuT1jBRjFvdtoHsqD58IRHy1nf86paRg=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.6.tgz",
+      "integrity": "sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA=="
     },
     "@babel/code-frame": {
       "version": "7.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7680,11 +7680,6 @@
           "bundled": true,
           "dev": true
         },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true,
-          "dev": true
-        },
         "init-package-json": {
           "version": "1.10.3",
           "bundled": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2823,9 +2823,9 @@
       "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
     },
     "commitizen": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/commitizen/-/commitizen-4.2.0.tgz",
-      "integrity": "sha512-dMTgCkmxDOaH32HViVyvoGqVzCAyvBsgMViWnIDQxVHlEwHS1d6d8rweCGE7fjCROryBZmHRQrWVWN9GTw2F/g==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/commitizen/-/commitizen-4.2.1.tgz",
+      "integrity": "sha512-nZsp8IThkDu7C+93BFD/mLShb9Gd6Wsaf90tpKE3x/6u5y/Q52kzanIJpGr0qvIsJ5bCMpgKtr3Lbu3miEJfaA==",
       "dev": true,
       "requires": {
         "cachedir": "2.2.0",
@@ -3215,9 +3215,9 @@
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
     },
     "cz-conventional-changelog": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.2.1.tgz",
-      "integrity": "sha512-MroXCfO8sahklT0KSwZ1oaNwKxZaZ2A8ONc+MH+is8QDZ2zBhGOFFiAXuWpcWFJLpxlGPvnYlhvOlYiSOAGc7w==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.3.0.tgz",
+      "integrity": "sha512-U466fIzU5U22eES5lTNiNbZ+d8dfcHcssH4o7QsdWaCcRs/feIPCxKYSWkYBNs5mny7MvEfwpTLWjvbm94hecw==",
       "dev": true,
       "requires": {
         "@commitlint/load": ">6.1.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ export = (app: Probot, { getRouter }: ApplicationFunctionOptions) => {
     }
 
     const branch = head.ref;
-    log.debug(`Confirmed configuration of %s branch in %s: %s`, branch, project, config);
+    log.debug(`Confirmed configuration of %s branch in %s: %s`, branch, project, JSON.stringify(config));
 
     const translates = await rtd.getTranslates(project);
 


### PR DESCRIPTION
Follow [latest breaking changes](https://github.com/probot/probot/releases/tag/v11.0.0) especially:

> context.github has been removed. Use context.octokit instead
> app.route() has been removed. Use the getRouter() argument from the app function instead: (app, { getRouter }) => { ... }
> import { Application } from probot has been removed. Use import { Probot } from probot instead, the APIs are the same

